### PR TITLE
Standard Ad Meta Tag Dimensions

### DIFF
--- a/generators/app/templates/dev/_index_standard.html
+++ b/generators/app/templates/dev/_index_standard.html
@@ -4,7 +4,7 @@
 
 <head>
     <title><%= bannerName %></title>
-    <meta name="ad.size" content="height=<%= actualBannerHeight %>,width=<%= actualBannerWidth %>">
+    <meta name="ad.size" content="width=<%= actualBannerWidth %>,height=<%= actualBannerHeight %>">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style type="text/css">
     #container_ad {


### PR DESCRIPTION
AdWords refused all Standard banners with the wrong order (hmm, wrong means in this case not as in the specs) of the meta tag ad dimensions.
