### PR TITLE
Fixes #4: Failing unit test

### DIFF
--- a/test/test-app.js
+++ b/test/test-app.js
@@ -15,7 +15,6 @@ describe('buildabanner:app', function () {
 
   it('creates files', function () {
     assert.file([
-      'bower.json',
       'package.json',
       '.editorconfig',
       '.jshintrc'


### PR DESCRIPTION
The "buildabanner:app creates files:" test fails because the
test is looking for a bower.json file that is not (and no
longer should) be created.

The fix is to no longer look for that file.
